### PR TITLE
Update Firebase config keys and replace signInWithRedirect with signInWithPopup in useAuth hook

### DIFF
--- a/src/api/config.js
+++ b/src/api/config.js
@@ -4,13 +4,13 @@ import { getAuth } from 'firebase/auth';
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
-	apiKey: 'FILL_ME_IN',
-	authDomain: 'FILL_ME_IN',
-	projectId: 'FILL_ME_IN',
-	storageBucket: 'FILL_ME_IN',
-	messagingSenderId: 'FILL_ME_IN',
-	appId: 'FILL_ME_IN',
-};
+	apiKey: "AIzaSyDmGxC-ITYFOyD6U1IrJAszf1KplXbG1Bs",
+	authDomain: "tcl-75-smart-shopping-list.firebaseapp.com",
+	projectId: "tcl-75-smart-shopping-list",
+	storageBucket: "tcl-75-smart-shopping-list.appspot.com",
+	messagingSenderId: "1081566633611",
+	appId: "1:1081566633611:web:b07badada6839daf2e3e8e"
+  };
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);

--- a/src/api/useAuth.jsx
+++ b/src/api/useAuth.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { auth } from './config.js';
-import { GoogleAuthProvider, signInWithRedirect } from 'firebase/auth';
+import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 import { addUserToDatabase } from './firebase.js';
 
 /**
@@ -11,7 +11,7 @@ import { addUserToDatabase } from './firebase.js';
 export const SignInButton = () => (
 	<button
 		type="button"
-		onClick={() => signInWithRedirect(auth, new GoogleAuthProvider())}
+		onClick={() => signInWithPopup(auth, new GoogleAuthProvider())}
 	>
 		Sign In
 	</button>


### PR DESCRIPTION
## Description

In this PR, I replaced the `signInWithRedirect` method with `signInWithPopup` in the `useAuth` hook. Additionally, I updated `config.js` with the required Firebase config keys, which is part of the initial setup for our project.

## Acceptance Criteria

- Replace `signInWithRedirect` with `signInWithPopup` in the `useAuth` hook.
- Update `config.js` with the Firebase config keys.

## Testing Steps / QA Criteria

1. Ensure `config.js` is updated with the correct Firebase config keys (from here: https://the-collab-lab.slack.com/archives/C0172ED75DL/p1723028088608819?thread_ts=1723027971.748089&cid=C0172ED75DL)
2. Ensure `signInWithRedirect` has been replaced with `signInWithPopup` in the `useAuth` hook.
