### PR TITLE
Revert "Issue 1"

### DIFF
--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,8 +1,7 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import { Outlet } from 'react-router-dom';
 
 import './Layout.css';
-import { auth } from '../api/config.js';
-import { useAuth, SignInButton, SignOutButton } from '../api/useAuth.jsx';
 
 /**
  * TODO: The links defined in this file don't work!
@@ -13,20 +12,11 @@ import { useAuth, SignInButton, SignOutButton } from '../api/useAuth.jsx';
  */
 
 export function Layout() {
-	const { user } = useAuth();
 	return (
 		<>
 			<div className="Layout">
 				<header className="Layout-header">
 					<h1>Smart shopping list</h1>
-					{!!user ? (
-						<div>
-							<span>Signed in as {auth.currentUser.displayName}</span> (
-							<SignOutButton />)
-						</div>
-					) : (
-						<SignInButton />
-					)}
 				</header>
 				<main className="Layout-main">
 					<Outlet />


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

It appears this repo was initialized with issue 1 completed. Thanks for pointing this out @ahsanatzapier!

## Related Issue

1

## Acceptance Criteria

As mentors, we need to be able to demo pair programming at our first sync using issue 1 as an example. In order to do so, the code to complete issue 1 should not be present.

## Type of Changes

Removing the code to complete issue 1.

## Updates

### Before

Before the code to complete issue 1 (show sign in and sign out buttons) was there.

### After

After the code to complete issue 1 is gone. the sign in and sign out buttons should not be visible or present on the page.

## Testing Steps / QA Criteria

1. I made the code changes
2. Ran `npm start` 
3. Viewed the site at `http://localhost:3000/`
4. Verified I could no longer see the sign in and sign out buttons
