### PR TITLE
change custom name to a variable item.name

### DIFF
--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -13,7 +13,7 @@ export function Home({ data, setListPath }) {
 					return (
 						<SingleList
 							key={item.name + index}
-							name="First List"
+							name={item.name}
 							path={item.path}
 							setListPath={setListPath}
 						/>


### PR DESCRIPTION
changed custom list name:
name={'First List'}
to a variable that is taken from item itself
name={item.name}

Before:
![home](https://github.com/user-attachments/assets/2fd4a75b-96b3-4649-ac41-bfdd36c83f48)

After:
![updated-home](https://github.com/user-attachments/assets/31f40465-691b-480d-b786-9d3d75bd4c34)

With current changes, users can see names relevant to each list regardless of the quantity of the lists.
