### PR TITLE
remove default value from input in ManageList

### DIFF
--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -63,7 +63,6 @@ export function ManageList() {
 					<br />
 					<input
 						type="text"
-						defaultValue=""
 						id="item-name"
 						onChange={handleTextChange}
 						value={itemName}


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

This code fixes a React warning 'Input elements must be either controlled or uncontrolled' and requires to have either value prop, or defaultValue prop, but not both

## Related Issue

closes #32 

## Acceptance Criteria

fixes a react warning

## Type of Changes

`warning fix` 

## Updates

### Before

![Screenshot 2024-08-25 130624](https://github.com/user-attachments/assets/3a66866d-1074-4cb9-9705-8fa169231f1d)

### After

![Screenshot 2024-08-26 090225](https://github.com/user-attachments/assets/b5983c4e-7796-4bc0-a02d-b44520fc5773)

## Testing Steps / QA Criteria

1. I ran npm start to start the application and went to localhost:3000
2. I clicked the "sign in" button > chose my gmail account > submit
3.  I navigated to '/manage-list'
4. I verified that React warning was no longer present in the console