### PR TITLE
Move try/catch example

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -136,17 +136,15 @@ export async function createList(userId, userEmail, listName) {
  * @param {string} listPath The path to the list to share.
  * @param {string} recipientEmail The email of the user to share the list with.
  */
-export async function shareList(listPath, currentUserId, recipientEmail) {
-	// Check if current user is owner.
-	if (!listPath.includes(currentUserId)) {
-		return 'match';
-	}
+export async function shareList(listPath, recipientEmail) {
 	// Get the document for the recipient user.
 	const usersCollectionRef = collection(db, 'users');
 	const recipientDoc = await getDoc(doc(usersCollectionRef, recipientEmail));
 	// If the recipient user doesn't exist, we can't share the list.
 	if (!recipientDoc.exists()) {
-		return;
+		throw new Error(
+			"The list was not shared because the recipient's email address does not exist in the system.",
+		);
 	}
 	// Add the list to the recipient user's sharedLists array.
 	const listDocumentRef = doc(db, listPath);
@@ -155,9 +153,8 @@ export async function shareList(listPath, currentUserId, recipientEmail) {
 		updateDoc(userDocumentRef, {
 			sharedLists: arrayUnion(listDocumentRef),
 		});
-		return true;
 	} catch {
-		return false;
+		throw new Error('An unknown error ocurred.');
 	}
 }
 

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -61,16 +61,14 @@ export function ManageList() {
 
 	const handleEmailInputSubmit = async (event) => {
 		event.preventDefault();
-		const listAdded = await shareList(listPath, userId, emailData);
-		if (listAdded === 'match') {
-			alert('You cannot share the list with yourself.');
-		} else if (listAdded === true) {
+
+		try {
+			await shareList(listPath, emailData);
 			alert('List was shared with recipient.');
-		} else {
-			alert(
-				"The list was not shared because the recipient's email address does not exist in the system.",
-			);
+		} catch (err) {
+			alert(err.message);
 		}
+
 		setEmailData('');
 	};
 


### PR DESCRIPTION
Likely not mergeable, but easier to show than attempt to explain.

Take this suggestion if you like it, but I was thinking maybe y'all could move the try/catch in the calling function `handleEmailInputSubmit` and then in the `shareList` you could lean on it being in a try/catch and throw errors with the messages you'd like to display in the `alerts` to simplify the logic a little bit.