### PR TITLE
Implement custom hook to check for listPath

### DIFF
--- a/src/hooks/useEnsureListPath.js
+++ b/src/hooks/useEnsureListPath.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/*
+ * This custom hook ensures that a user has a list path in localStorage.
+ * If not, it shows a user-friendly notification and redirects to the home page.
+ */
+
+export function useEnsureListPath() {
+	const navigate = useNavigate();
+	const [isChecking, setIsChecking] = useState(true);
+
+	useEffect(() => {
+		const listPath = localStorage.getItem('tcl-shopping-list-path');
+		if (!listPath) {
+			alert(
+				'It seems like you landed here without first creating a list or selecting an existing one. Please select or create a new list first. Redirecting to Home.',
+			);
+			navigate('/');
+		} else {
+			setIsChecking(false);
+		}
+	}, [navigate]);
+
+	return isChecking;
+}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,9 +2,13 @@ import { ListItem } from '../components';
 import { useState } from 'react';
 import { AddItems } from '../components/AddItems';
 import TextInputElement from '../components/TextInputElement';
+import { useEnsureListPath } from '../hooks/useEnsureListPath';
 
 export function List({ data, listPath }) {
 	const [searchItem, setSearchItem] = useState('');
+
+	// Redirect to home if no list path is null
+	if (useEnsureListPath()) return <></>;
 
 	const handleTextChange = (event) => {
 		setSearchItem(event.target.value);

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,7 +1,10 @@
 import { AddItems } from '../components/AddItems';
 import { ShareList } from '../components/ShareList';
+import { useEnsureListPath } from '../hooks/useEnsureListPath';
 
 export function ManageList({ items }) {
+	// Redirect to home if no list path is null
+	if (useEnsureListPath()) return <></>;
 	return (
 		<div>
 			<AddItems items={items} />

--- a/tests/ManageList.test.jsx
+++ b/tests/ManageList.test.jsx
@@ -1,9 +1,32 @@
 import { render, screen } from '@testing-library/react';
 import { ManageList } from '../src/views/ManageList';
+import { MemoryRouter } from 'react-router-dom';
+
+beforeEach(() => {
+	Object.defineProperty(window, 'localStorage', {
+		value: {
+			getItem: vi.fn((key) => {
+				if (key === 'tcl-shopping-list-path') {
+					return '/groceries';
+				}
+				return null;
+			}),
+			setItem: vi.fn(),
+			clear: vi.fn(),
+		},
+		writable: true,
+	});
+
+	vi.spyOn(window, 'alert').mockImplementation(() => {});
+});
 
 describe('ManageList Component', () => {
 	test('renders AddItems component with submit button and radio buttons', () => {
-		render(<ManageList />);
+		render(
+			<MemoryRouter>
+				<ManageList />
+			</MemoryRouter>,
+		);
 
 		expect(screen.getByLabelText('Item Name:')).toBeInTheDocument();
 		expect(screen.getByLabelText('Soon')).toBeInTheDocument();
@@ -13,9 +36,27 @@ describe('ManageList Component', () => {
 	});
 
 	test('renders ShareList component with email input and invite button', () => {
-		render(<ManageList />);
+		render(
+			<MemoryRouter>
+				<ManageList />
+			</MemoryRouter>,
+		);
 
 		expect(screen.getByPlaceholderText('Enter email')).toBeInTheDocument();
 		expect(screen.getByText('Invite User')).toBeInTheDocument();
+	});
+
+	test('triggers alert and redirects when no list path is found in localStorage', () => {
+		window.localStorage.getItem.mockReturnValueOnce(null);
+
+		render(
+			<MemoryRouter>
+				<ManageList />
+			</MemoryRouter>,
+		);
+
+		expect(window.alert).toHaveBeenCalledWith(
+			'It seems like you landed here without first creating a list or selecting an existing one. Please select or create a new list first. Redirecting to Home.',
+		);
 	});
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -8,3 +8,5 @@ import { vi } from 'vitest';
 vi.mock('@the-collab-lab/shopping-list-utils', () => ({
 	calculateEstimate: vi.fn(),
 }));
+
+window.alert = vi.fn();


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

This PR introduces a custom hook, `useEnsureListPath`, that checks for the presence of a saved list path in localStorage. If the list path does not exist, the user receives a notification and is redirected to the home page. The goal is to improve user experience by ensuring users are properly routed when they attempt to access protected pages without selecting or creating a list first.

## Acceptance Criteria

- If there is no list path in localStorage, the user is redirected to the home page.
- The user receives a notification that informs them why they are being redirected.

## Type of Changes

- Enhancement

## Updates

### Before

- The list view loads on a black page with no feedback to the user when a listPath doesn't exist.

### After

- When a user tries to access a protected page without a list, they are gracefully notified and redirected to the home page.

## Testing Steps / QA Criteria

- Start the app and clear any localStorage entries related to the list path (tcl-shopping-list-path).
- Navigate to List or Manage List view.
- Observe notification informing you about the need to create/select a list.