### PR TITLE
[ISSUE 61] - Navigate to a clicked on list automatically

### DIFF
--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -1,8 +1,14 @@
+import { useNavigate } from 'react-router-dom';
 import './SingleList.css';
 
 export function SingleList({ name, path, setListPath }) {
+	const navigate = useNavigate();
+
 	function handleClick() {
 		setListPath(path);
+		setTimeout(() => {
+			navigate('/list');
+		}, 200);
 	}
 
 	return (


### PR DESCRIPTION
This pull request suggests a functionality that allows a user to be automatically redirected to the list page when clicking on a list name on the home page. 

## Description

`SingleList` component on click navigates to a '/list' page via `useNavigate()`. A `setTimeout` is added to ensure a smooth experience.


## Related Issue

closes #61 

## Acceptance Criteria

- [x]  Clicking on a list name redirects the user to the appropriate list page automatically.
- [x]  Tests, Documentation, and ChangeLogs are updated accordingly.
- [ ]  Peer reviews and approvals from the team.

## Type of Changes

`enhancement`

## Updates
### After

![navigate-ezgif com-speed](https://github.com/user-attachments/assets/9445dd4d-8a84-49f8-a6a6-16c05637ce73)

## Testing Steps / QA Criteria

- ran npm start and signed in
- clicked on list names to ensure redirection

