### PR TITLE
[ISSUE 22] - Add new items from list page

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useEnsureListPath } from '../hooks/useEnsureListPath';
-import { List as UnorderedList } from '@mui/material';
+import { List as UnorderedList, Box, Grid } from '@mui/material';
 import { TextInputElement, AddItems, ListItem } from '../components';
 
 export function List({ data, listPath }) {
@@ -31,17 +31,31 @@ export function List({ data, listPath }) {
 			) : (
 				<>
 					<p>{listName}</p>
+					<Box sx={{ flexGrow: 1 }}>
+						<Grid
+							container
+							spacing={8}
+							columns={16}
+							justifyContent="space-between"
+						>
+							<Grid item size={{ xs: 2, sm: 4, md: 4 }}>
+								<AddItems items={data} />
+							</Grid>
+							<Grid item size={{ xs: 2, sm: 4, md: 4 }}>
+								<form onSubmit={(event) => event.preventDefault()}>
+									<TextInputElement
+										id="search-item"
+										type="search"
+										placeholder="Search Item..."
+										required={true}
+										onChange={handleTextChange}
+										label="Search Item:"
+									/>
+								</form>
+							</Grid>
+						</Grid>
+					</Box>
 
-					<form onSubmit={(event) => event.preventDefault()}>
-						<TextInputElement
-							id="search-item"
-							type="search"
-							placeholder="Search Item..."
-							required={true}
-							onChange={handleTextChange}
-							label="Search Item:"
-						/>
-					</form>
 					<UnorderedList>
 						{filteredItems.map((item) => {
 							return <ListItem key={item.id} item={item} listPath={listPath} />;

--- a/tests/List.test.jsx
+++ b/tests/List.test.jsx
@@ -49,4 +49,18 @@ describe('List Component', () => {
 		expect(screen.getByLabelText('Not soon')).toBeInTheDocument();
 		expect(screen.getByText('Submit')).toBeInTheDocument();
 	});
+
+	test('shows AddItems component with existing items', () => {
+		render(
+			<MemoryRouter>
+				<List data={mockShoppingListData} listPath={'/groceries'} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByLabelText('Item Name:')).toBeInTheDocument();
+		expect(screen.getByLabelText('Soon')).toBeInTheDocument();
+		expect(screen.getByLabelText('Kind of soon')).toBeInTheDocument();
+		expect(screen.getByLabelText('Not soon')).toBeInTheDocument();
+		expect(screen.getByText('Submit')).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
## Description

- This code simply adds AddItems component to the List component. 
- MUI components, such as Box and Grid, are used to create an appealing layout, following Material Design's recommended responsive grid system. 
- The tests have been updated to ensure that the AddItems component is displayed, even if the user has no items added to the selected list.

## Related Issue

Closes #68 

## Acceptance Criteria

- [x] Users can add items without navigating away from the list view.
- [x] Tests, Documentation, and ChangeLogs are updated to reflect this change.

## Type of Changes

`enhancement` 


## Updates

### Before

![Screenshot 2024-10-16 103902](https://github.com/user-attachments/assets/ec00804d-4762-487f-a8dc-aaede0d57f66)

### After

![Screenshot 2024-10-16 103555](https://github.com/user-attachments/assets/e13f0ece-d5bd-474a-8e00-c4cd28b8d91c)

## Testing Steps / QA Criteria

1. Ran npm start and went to localhost
2. Opened lists with items and ensured that AddItems component is being displayed
